### PR TITLE
Fixed URL reference for icons-36-white.png

### DIFF
--- a/aspnet/ajax/cdn/jquery-mobile/cdnjquerymobile110.md
+++ b/aspnet/ajax/cdn/jquery-mobile/cdnjquerymobile110.md
@@ -30,4 +30,4 @@ The jQuery Mobile 1.1.0 library includes the following files:
 - https://ajax.aspnetcdn.com/ajax/jquery.mobile/1.1.0/images/icons-18-black.png
 - https://ajax.aspnetcdn.com/ajax/jquery.mobile/1.1.0/images/icons-18-white.png
 - https://ajax.aspnetcdn.com/ajax/jquery.mobile/1.1.0/images/icons-36-black.png
-- https://ajax.aspnetcdn.com/ajax/jquery.mobile/1.1.0/imagesicons-36-white.png
+- https://ajax.aspnetcdn.com/ajax/jquery.mobile/1.1.0/images/icons-36-white.png


### PR DESCRIPTION
Fixes a typo in the URL location for the resource `icons-36-white.png`